### PR TITLE
feat(article): Phase 6 — full TIL draft

### DIFF
--- a/article/benford-law-til-pt-BR.md
+++ b/article/benford-law-til-pt-BR.md
@@ -1,0 +1,236 @@
+# Lei de Benford: duas derivações, quatro testes, um detector de fraude
+
+> O primeiro dígito de dados numéricos "naturais" não é uniforme, mas logarítmico: $P(d) = \log_{10}(1 + 1/d)$, de modo que um 1 inicial ocorre cerca de 30 % das vezes e um 9 inicial menos de 5 %. Este TIL apresenta duas derivações rigorosas independentes, quatro testes de conformidade e uma demonstração ponta a ponta de detecção de fraude.
+
+---
+
+## 1. As páginas gastas de uma tábua de logaritmos
+
+Em 1881 o astrônomo Simon Newcomb percebeu algo estranho ao folhear seu exemplar de uma tábua de logaritmos. As primeiras páginas — aquelas para números começando com 1 — estavam imundas e com as pontas dobradas; as últimas páginas, para números começando com 9, estavam limpas e intactas. Uma tábua de logaritmos é a mais teimosamente mecânica das referências. Não há enredo, nem narrativa, nenhuma forma de alguns capítulos serem mais interessantes que outros. Por que, então, as primeiras páginas estavam gastas?
+
+Newcomb escreveu uma nota de duas páginas no *American Journal of Mathematics* argumentando que o primeiro dígito significativo de dados numéricos "naturais" não é uniforme, mas logarítmico:
+
+$$
+P(d) = \log_{10}\!\left(1 + \frac{1}{d}\right), \qquad d \in \{1, 2, \ldots, 9\}.
+$$
+
+O 1 inicial deveria aparecer cerca de 30,1 % das vezes; o 9 inicial, menos de 5 %. A "demonstração" de Newcomb era uma heurística sobre a mantissa de um número aleatório ser uniforme; ele não apresentou argumento formal nem dados empíricos, e a nota deslizou para a obscuridade.
+
+Frank Benford redescobriu a regularidade em 1938 pela ponta oposta. Físico da General Electric, ele tabulou dígitos iniciais em vinte conjuntos de dados não correlacionados — comprimentos de rios, pesos atômicos, estatísticas de beisebol, áreas de superfície de países — e mostrou que a mesma curva logarítmica se ajustava a todos. Benford também não derivou a fórmula; o que ele forneceu foi a massa empírica de evidência que Newcomb havia pulado. O padrão recebeu o nome dele, não o de Newcomb.
+
+A justificação matemática esperou até 1961, quando Roger Pinkham provou que qualquer lei de dígito inicial que não dependa da unidade de medida tem de ser a curva de Benford. Esse argumento — *invariância de escala força a lei* — é o que faz Benford ser mais que um teorema folclórico. É a razão de este TIL existir: a mesma distribuição logarítmica aparece em duas derivações não correlacionadas, uma probabilística e outra estrutural, e o fato de elas se encontrarem é a evidência mais forte possível de que a lei não é coincidência.
+
+O resto é detalhe.
+
+---
+
+## 2. Benford empírico em três conjuntos de dados
+
+Três conjuntos de dados, três regimes, uma curva.
+
+![Distribuições empíricas de primeiro dígito vs a PMF de Benford.](../figures/empirical_match.png)
+
+**Populações de cidades do mundo.** O snapshot empacotado do GeoNames `cities5000` lista ~68.000 cidades com pelo menos 5.000 habitantes. O empírico $\hat P(1) \approx 0{,}31$, $\hat P(9) \approx 0{,}06$, monotonamente decrescente exceto por um pequeno pico em $d = 5$ (artefato do corte de 5.000 habitantes — toda cidade *logo acima* do limiar tem 5 inicial). Este é o exemplo canônico: dados geográficos reais cobrindo várias ordens de magnitude (~$10^3$ a $10^7$), originados do mesmo processo multiplicativo de crescimento entre continentes.
+
+**Números de Fibonacci.** $F_1, \ldots, F_{1000}$, computados via fórmula fechada de Binet. A distribuição de primeiro dígito é *exatamente* Benford no limite: o teorema da equidistribuição de Weyl diz que a sequência $n \log_{10}(\varphi) \bmod 1$ é equidistribuída em $[0, 1)$, e a §3 transformará isso na PMF de Benford diretamente. Mesmo para $n = 1000$ o ajuste empírico fica dentro de ~4 % por célula.
+
+**Alturas de adultos.** Sintético, $n = 10{.}000$, $\mathcal{N}(170, 10)$ centímetros. *Não* é Benford: os dados cobrem menos de uma ordem de magnitude (a maior parte dos valores fica entre 150 e 190 cm), de modo que a distribuição de primeiro dígito colapsa em "quase tudo começa com 1". $\hat P(1) > 0{,}55$, vários dígitos completamente ausentes. Este é o controle negativo — a classe de dados a que Benford explicitamente não se aplica.
+
+As três curvas capturam a faixa operacional. Benford aparece sempre que os dados cobrem várias ordens de magnitude *multiplicativamente*. Falha onde os dados vivem numa escala aditiva de quantidades semelhantes (alturas, pontuações de QI, notas de prova). As próximas duas seções derivam a razão matemática para essa divisão.
+
+---
+
+## 3. Primeira derivação: a mantissa é uniforme em $[0, 1)$
+
+Escreva qualquer real positivo $X$ em notação científica:
+
+$$
+X = r \cdot 10^k, \qquad r \in [1, 10), \quad k \in \mathbb{Z}.
+$$
+
+O fator $r$ é a **mantissa** e $k$ a ordem de magnitude. O primeiro dígito significativo de $X$ é simplesmente $\lfloor r \rfloor$. Tome logaritmos:
+
+$$
+\log_{10}(X) = \log_{10}(r) + k, \qquad \log_{10}(r) \in [0, 1).
+$$
+
+Defina a **log-mantissa** $Y = \log_{10}(X) \bmod 1$. Por construção $Y \in [0, 1)$, e o primeiro dígito de $X$ é determinado por qual subintervalo de $[0, 1)$ contém $Y$:
+
+$$
+D(X) = d \iff \log_{10}(d) \le Y < \log_{10}(d + 1).
+$$
+
+Até aqui é apenas notação. A premissa probabilística é a próxima frase.
+
+> **Premissa (mantissa log-uniforme).** $Y \sim \mathrm{Uniforme}(0, 1)$.
+
+Se aceitamos isso, a distribuição de primeiro dígito sai numa única linha:
+
+$$
+P(D = d) \;=\; \Pr[\log_{10}(d) \le Y < \log_{10}(d + 1)] \;=\; \log_{10}(d + 1) - \log_{10}(d) \;=\; \log_{10}\!\left(1 + \frac{1}{d}\right).
+$$
+
+Essa é toda a derivação.
+
+![Intuição da mantissa uniforme.](../figures/log_uniform_intuition.png)
+
+A questão substantiva é *por que* a premissa deveria valer. Três argumentos:
+
+**Processos multiplicativos.** Muitas quantidades naturais são produtos de fatores independentes: a população de uma cidade no ano $t$ é $p_0 \prod_i (1 + r_i)$ para taxas de crescimento $r_i$. Tomar logaritmos transforma o produto em soma, e o teorema central do limite faz $\log_{10}(X)$ aproximadamente gaussiano — mas com variância que cresce com o número de fatores. À medida que a variância cresce, a *parte fracionária* $Y$ se aproxima da uniforme em $[0, 1)$ independentemente de onde a média esteja. A maioria dos vinte conjuntos de Benford é multiplicativa nesse sentido.
+
+**Equidistribuição.** Para uma sequência determinística como $X_n = a^n$ com $\log_{10}(a)$ irracional, o teorema da equidistribuição de Weyl diz que $\{n \log_{10}(a)\} \bmod 1$ é equidistribuída em $[0, 1)$. A distribuição empírica de primeiro dígito converge *exatamente* para Benford. Fibonacci é o exemplo mais limpo: $F_n \sim \varphi^n / \sqrt{5}$, e $\log_{10}(\varphi)$ é irracional.
+
+**Unicidade teórico-medida.** Medidas de probabilidade invariantes por translação no círculo $\mathbb{R}/\mathbb{Z}$ são únicas a menos de normalização (medida de Haar). A seção 4 transforma essa observação na derivação de Pinkham.
+
+A premissa é *carga estrutural*: se a log-mantissa não for uniforme, a distribuição de primeiro dígito é o que segue da densidade real de $Y$. Um $X$ gaussiano centrado em $\log_{10}(170) \approx 2{,}23$ — alturas de adultos em centímetros — produz uma densidade de $Y$ aguda em torno de $0{,}23$, o que corresponde a um primeiro dígito grudado em $1$. A frequência de 55 % de 1 inicial no conjunto de alturas da §2 é exatamente esse efeito tornado visível.
+
+Logo a primeira derivação responde à pergunta "*dada* uma mantissa log-uniforme, qual é a lei de primeiro dígito?" — mas não "*por que* a mantissa deveria ser log-uniforme?". Essa lacuna é fechada por Pinkham.
+
+---
+
+## 4. Segunda derivação: invariância de escala força $1/x$
+
+Moeda é a motivação mais limpa. Tome um conjunto de receitas em BRL. Converta para USD multiplicando cada entrada por alguma taxa de câmbio $c$. A distribuição de primeiro dígito não deveria mudar só porque rotulamos a unidade de outra forma. Formalmente:
+
+> **Invariância de escala.** $\Pr[D(cX) = d] = \Pr[D(X) = d]$ para todo $c > 0$ e todo $d \in \{1, \ldots, 9\}$.
+
+É uma restrição forte. Exclui, por exemplo, a distribuição uniforme nos dígitos — uniforme em uma moeda não será uniforme depois de multiplicar cada valor por $\pi$.
+
+Tome logaritmos novamente. Com $Y = \log_{10}(X) \bmod 1$ e $\alpha = \log_{10}(c) \bmod 1$, a multiplicação $X \mapsto cX$ age sobre $Y$ como uma translação:
+
+$$
+Y \;\mapsto\; (Y + \alpha) \bmod 1.
+$$
+
+O conjunto de $\alpha$ atingíveis enquanto $c$ percorre $(0, \infty)$ é o intervalo $[0, 1)$ inteiro. Logo invariância de escala é *equivalente* a invariância por translação de $Y$ no círculo $\mathbb{R}/\mathbb{Z}$. E existe exatamente uma distribuição de probabilidade invariante por translação no círculo: a uniforme.
+
+Invariância de escala portanto força $Y \sim \mathrm{Uniforme}(0, 1)$, o que pela §3 força a PMF de Benford. O argumento é limpo o suficiente para merecer um nome; é o **teorema de Pinkham**.
+
+Há uma rota complementar pela *densidade* em vez de pela log-mantissa. Em uma janela finita $[a, b] \subset (0, \infty)$ a única densidade de probabilidade invariante por multiplicação é
+
+$$
+f(x) = \frac{1}{x \log(b/a)}.
+$$
+
+Restringindo a $[10^k, 10^{k+1})$,
+
+$$
+P(D = d) = \int_{d \cdot 10^k}^{(d+1) \cdot 10^k} \frac{1}{x \ln 10}\, dx = \log_{10}\!\left(1 + \frac{1}{d}\right).
+$$
+
+O fator $10^k$ cancela. Esse cancelamento *é* a invariância de escala, em forma aritmética.
+
+![Multiplicando populações de cidades por várias constantes. A distribuição de primeiro dígito não se mexe.](../figures/scale_invariance.png)
+
+Dois corolários que merecem destaque:
+
+**Invariância de base.** Repetindo a derivação na base $b > 1$ obtemos $P_b(d) = \log_b(1 + 1/d)$ para $d \in \{1, \ldots, b-1\}$. Em octal, $P_8(1) = \log_8 2 = 1/3$, ligeiramente mais que o decimal $P_{10}(1) \approx 0{,}301$. Mesma forma, suporte distinto. A escolha da base 10 é um artefato notacional; a lei é estrutural.
+
+**Por que duas derivações importam.** A §3 parte de uma premissa probabilística (mantissa log-uniforme) e aterrissa em $\log_{10}(1 + 1/d)$. A §4 parte de uma premissa estrutural (sem unidade preferida) e aterrissa em $\log_{10}(1 + 1/d)$. A §4 *implica* a premissa da §3, então as duas não são literalmente independentes — mas são *estruturalmente* distintas. O fato de duas hipóteses não correlacionadas convergirem para a mesma fórmula é a evidência mais forte de que a lei não é um acidente empírico.
+
+A próxima pergunta é operacional: dado um conjunto de dados real, como *testamos* se ele se conforma?
+
+---
+
+## 5. Testando conformidade: $\chi^2$, KS, MAD, $Z$
+
+Quatro testes, quatro sensibilidades. Tome uma distribuição empírica de primeiro dígito $\hat P(1), \ldots, \hat P(9)$ em uma amostra de tamanho $n$ e pergunte: o quão próxima está da PMF de Benford?
+
+![O bundle dos quatro testes em três conjuntos de referência.](../figures/conformity_test_demo.png)
+
+**$\chi^2$ de Pearson.** Trate o vetor de contagens $(O_1, \ldots, O_9)$ como multinomial com parâmetros $(n; P(1), \ldots, P(9))$ sob a hipótese nula. A estatística
+
+$$
+\chi^2 = \sum_{d=1}^{9} \frac{(O_d - n P(d))^2}{n P(d)}
+$$
+
+é assintoticamente $\chi^2_8$ — a restrição $\sum_d O_d = n$ remove um grau de liberdade das nove células. Rejeita-se em $\alpha = 0{,}05$ se $\chi^2 > 15{,}51$. O qui-quadrado é o teste de hipótese honesto para $n$ moderado, mas tem uma falha conhecida: para $n$ muito grande ($\sim 10^6$), até desvios microscópicos (~0,001 por célula) tornam-se "estatisticamente significativos". O teste responde "o desvio é literalmente zero?", o que raramente é a pergunta de interesse na prática.
+
+**Kolmogorov–Smirnov.** $D_n = \max_d |F_n(d) - F(d)|$, onde $F$ é a CDF cumulativa de Benford. Sensível a *deriva sistemática* ao longo das células de modo que o $\chi^2$ dilui na média. A distribuição assintótica de Kolmogorov fornece um p-valor via $\sqrt{n}\, D_n$, mas é conservadora numa distribuição discreta — útil como diagnóstico, não como teste afiado.
+
+**MAD com limiares de Nigrini.** A estatística mais simples, $\mathrm{MAD} = \tfrac{1}{9} \sum_d |\hat P(d) - P(d)|$, é **invariante ao tamanho da amostra**: um vetor de proporções produz o mesmo valor para $n = 1{.}000$ ou $n = 10^7$. *Benford's Law* (Wiley, 2012) de Mark Nigrini calibra uma escala de veredito: $< 0{,}006$ "conformidade próxima"; $< 0{,}012$ "aceitável"; $< 0{,}015$ "marginalmente aceitável"; $\ge 0{,}015$ "não-conformidade". MAD não tem distribuição amostral formal nem p-valor — mas é o único dos quatro que escala razoavelmente para dados de auditoria forense onde $n \gg 10^5$.
+
+**$Z$ por dígito.** Para cada $d$, trate $O_d \sim \mathrm{Binomial}(n, P(d))$ e calcule o $z_d$ bilateral padronizado (com correção de continuidade de Yates). Rejeita-se em $\alpha = 0{,}05$ se $|z_d| > 1{,}96$. O $Z$ por dígito não controla a taxa de erro familiar entre as nove células — é um *diagnóstico*: se só a célula 1 é sinalizada, faltam 1s iniciais nos dados; se $\{8, 9\}$ são sinalizadas, os dados mostram viés de números redondos.
+
+A regra para escolher entre os quatro:
+
+| Pergunta | Teste |
+|---|---|
+| Teste de hipótese honesto, $n$ moderado | $\chi^2$ |
+| Deriva cumulativa entre células | KS |
+| Auditoria em escala forense, $n \gg 10^5$ | MAD |
+| *Qual* dígito está fora? | $Z$ por dígito |
+
+Na prática, rode os quatro. A implementação está em `src.conformity.conformity_report`.
+
+---
+
+## 6. Demo de fraude: quando números fabricados se entregam
+
+A Fase 5 fecha o ciclo. Pegue um conjunto limpo, conforme a Benford, substitua uma fração de suas entradas por valores fabricados e veja o bundle dos quatro testes cruzar de *aceitar* para *rejeitar*.
+
+![Populações de cidades limpas vs contaminadas a 30 %.](../figures/fraud_before_after.png)
+
+A leva fabricada é calibrada para parecer superficialmente plausível: amostrada na mesma janela de magnitude dos dados originais, de modo que o sinal de fraude vive na *distribuição de dígitos* e não na ordem de grandeza. Três estratégias de fabricação estão implementadas em `src.fraud`:
+
+1. **Dígito uniforme.** Cada dígito inicial aparece ~11,1 %. A violação de manual.
+2. **Números redondos.** Valores se concentram em $100, 200, 250, 500, 1{.}000, 2{.}000, 5{.}000, 10{.}000$, imitando o fraudador que arredonda mentalmente.
+3. **Psicológica.** Humanos pedidos para escrever números "aleatórios" superestimam os dígitos médios 3–6 e subestimam 1 e 9.
+
+Varrendo a fração de contaminação de 0 % a 100 % e rodando o bundle dos quatro testes 30 vezes em cada nível obtém-se a **curva de poder de detecção**:
+
+![Poder de detecção em três estratégias de fabricação no GeoNames cities5000.](../figures/fraud_detection_power.png)
+
+A curva MAD sobe pelos níveis de veredito de Nigrini (aceitável → marginalmente aceitável → não-conformidade) dentro dos primeiros 5–10 % de contaminação. A estatística $\chi^2$ de Pearson — em escala logarítmica — sobe íngreme através do seu valor crítico $\alpha = 0{,}05$ de 15,51 mais ou menos no mesmo ponto. A taxa empírica de rejeição em $\alpha = 0{,}05$ satura próxima de 1 para as três estratégias por volta de 10–15 % de contaminação.
+
+A leitura: nesse tamanho amostral, uma auditoria estilo Benford detecta de modo confiável fraude sempre que 10 % ou mais das entradas forem fabricadas por qualquer das três estratégias. Abaixo de 5 %, o poder de detecção varia — fabricação por números redondos é a mais difícil de pegar porque preserva o viés de dígito inicial de Benford ao mesmo tempo em que o desloca para $\{1, 2, 5\}$.
+
+Este experimento não é apenas um brinquedo. Casos históricos documentados incluem:
+
+- **Estatísticas fiscais gregas (2010).** Rauch, Göttsche, Brähler & Engel (2011, *German Economic Review*) aplicaram análise de primeiro dígito a relatórios macroeconômicos de déficit dos Estados-membros da UE para 1999–2009 e encontraram a Grécia como o único Estado cujos relatórios violavam significativamente Benford — publicado meses antes do reconhecimento oficial de manipulação estatística.
+- **Eleição presidencial iraniana de 2009.** Múltiplas análises *post hoc* (Mebane e trabalhos subsequentes) encontraram anomalias compatíveis com irregularidades estilo Benford no nível de seção eleitoral.
+- **Contabilidade forense.** *Benford's Law* (2012) de Mark Nigrini é o livro-texto do praticante, aplicado em milhares de conjuntos corporativos.
+
+O script `scripts/exp_fraud_demo.py` reproduz o *mecanismo* pelo qual essas auditorias funcionam: sob a hipótese nula, a distribuição empírica de primeiro dígito assenta sobre a curva de Benford; a contaminação a empurra para fora, e os testes de conformidade medem o empurrão.
+
+---
+
+## 7. Quando Benford falha, e por que isso também é útil
+
+A Lei de Benford não é uma lei universal dos números. Aplica-se a conjuntos de dados cujos valores cobrem várias ordens de magnitude *multiplicativamente* e são gerados por um processo que mistura escalas. Falha — de modo agudo — em pelo menos três classes de dados:
+
+1. **Dados limitados em escala aditiva.** Alturas de adultos, temperaturas corporais, pontuações de QI, notas de prova. Os valores ficam dentro de uma ordem de magnitude, então a log-mantissa $Y$ é fortemente concentrada e a distribuição de primeiro dígito colapsa no dígito que dominar o suporte. O exemplo das alturas na §2 é o caso de manual.
+
+2. **Identificadores atribuídos.** Telefones, CEPs, números de seguro social, números de RG. São amostrados de um desenho combinatório fixo, não gerados por processo multiplicativo; o dígito inicial é um artefato estrutural da autoridade emissora.
+
+3. **Dados truncados.** Qualquer conjunto com piso ou teto rígido distorce a distribuição de primeiro dígito perto do corte. O `cities5000` do GeoNames mostra um pequeno pico em $d = 5$ exatamente por essa razão — toda cidade *logo acima* do limiar de 5.000 habitantes tem 5 inicial.
+
+As falhas são operacionalmente úteis. Um conjunto de dados que *deveria* conformar-se a Benford e não se conforma é um sinal: ou o processo gerador não é o que você pensava, ou os dados foram adulterados. A contabilidade forense usa isso assimetricamente — um conjunto conforme a Benford é não-informativo; um conjunto que falha em Benford é a pergunta que vale a pena fazer.
+
+---
+
+## 8. Conclusões
+
+1. **A PMF de Benford $P(d) = \log_{10}(1 + 1/d)$ é estrutural, não coincidência.** Duas derivações não correlacionadas — mantissa log-uniforme e invariância de escala — convergem para a mesma curva. A convergência *é* a evidência.
+
+2. **Invariância de escala é a razão mais profunda.** O argumento de Pinkham mostra que qualquer lei de dígito inicial independente de unidade *tem* de ser a curva de Benford. A heurística da mantissa de Newcomb é corolário do enunciado mais forte, não fato independente.
+
+3. **Conformidade é testável, com quatro estatísticas complementares.** $\chi^2$ de Pearson para teste honesto de hipótese; KS para deriva cumulativa; MAD com limiares de Nigrini para auditoria em escala forense ($n \gg 10^5$); $Z$ por dígito para localizar *qual* dígito está fora. Rode os quatro.
+
+4. **Detecção de fraude é a aplicação mais limpa.** Com o conjunto de cidades GeoNames em $n \approx 68{.}000$, o bundle de Benford sinaliza de modo confiável contaminação de 10 % ou mais por qualquer das três estratégias de fabricação testadas.
+
+5. **Benford falha em dados limitados, aditivos ou atribuídos.** As falhas são operacionalmente úteis: um conjunto que *deveria* se conformar e não se conforma é o que vale a pena investigar.
+
+O código, derivações, exercícios e figuras estão no repositório companheiro: <https://github.com/brunoramosmartins/benford-law-til>.
+
+---
+
+## Referências
+
+- **Newcomb, S.** (1881). Note on the frequency of use of the different digits in natural numbers. *American Journal of Mathematics*, **4**(1), 39–40.
+- **Benford, F.** (1938). The law of anomalous numbers. *Proceedings of the American Philosophical Society*, **78**(4), 551–572.
+- **Pinkham, R. S.** (1961). On the distribution of first significant digits. *Annals of Mathematical Statistics*, **32**(4), 1223–1230.
+- **Hill, T. P.** (1995). A statistical derivation of the significant-digit law. *Statistical Science*, **10**(4), 354–363.
+- **Nigrini, M. J.** (2012). *Benford's Law: Applications for Forensic Accounting, Auditing, and Fraud Detection*. Wiley.
+- **Berger, A. & Hill, T. P.** (2015). *An Introduction to Benford's Law*. Princeton University Press.
+- **Rauch, B., Göttsche, M., Brähler, G. & Engel, S.** (2011). Fact and fiction in EU-governmental economic data. *German Economic Review*, **12**(3), 243–255.

--- a/article/benford-law-til.md
+++ b/article/benford-law-til.md
@@ -1,0 +1,236 @@
+# Benford's Law: two derivations, four tests, one fraud detector
+
+> The first digit of "natural" numerical data is not uniform but logarithmic: $P(d) = \log_{10}(1 + 1/d)$, so a leading 1 occurs about 30% of the time and a leading 9 less than 5%. This TIL gives two independent rigorous derivations, four conformity tests, and an end-to-end fraud-detection demo.
+
+---
+
+## 1. The worn pages of a logarithm table
+
+In 1881 the astronomer Simon Newcomb noticed something odd while flipping through his copy of a book of logarithms. The early pages — those for numbers starting with 1 — were filthy and dog-eared; the later pages, for numbers starting with 9, were crisp and clean. A logarithm table is the most stubbornly mechanical of references. There is no plot, no narrative, no way for some chapters to be more interesting than others. So why were the early pages worn out?
+
+Newcomb wrote a two-page note in the *American Journal of Mathematics* arguing that the first significant digit of "natural" numerical data is not uniform but logarithmic:
+
+$$
+P(d) = \log_{10}\!\left(1 + \frac{1}{d}\right), \qquad d \in \{1, 2, \ldots, 9\}.
+$$
+
+The leading 1 should appear about 30.1 % of the time, the leading 9 less than 5 %. Newcomb's "proof" was a heuristic about the mantissa of a random number being uniform; he gave no formal argument and no empirical data, and the note slid into obscurity.
+
+Frank Benford rediscovered the regularity in 1938 from the opposite end. A physicist at General Electric, he tabulated leading digits across twenty unrelated datasets — river lengths, atomic weights, baseball statistics, the surface areas of countries — and showed that the same logarithmic curve fit them all. Benford did not derive the formula either; what he provided was the empirical mass of evidence Newcomb had skipped. The pattern got his name, not Newcomb's.
+
+The mathematical justification waited until 1961, when Roger Pinkham proved that any leading-digit law that does not depend on the unit of measurement must be the Benford curve. That argument — *scale invariance forces the law* — is what makes Benford more than a folk theorem. It is the reason this TIL exists: the same logarithmic distribution appears in two unrelated derivations, one probabilistic and one structural, and the fact that they meet is the strongest possible evidence that the law is not a coincidence.
+
+The rest is detail.
+
+---
+
+## 2. Empirical Benford in three datasets
+
+Three datasets, three regimes, one curve.
+
+![Empirical first-digit distributions vs the Benford PMF.](../figures/empirical_match.png)
+
+**World city populations.** The bundled GeoNames `cities5000` snapshot lists ~68,000 cities with at least 5,000 inhabitants. The empirical $\hat P(1) \approx 0.31$, $\hat P(9) \approx 0.06$, monotonically decreasing apart from a small spike at $d = 5$ (an artefact of the 5,000-population cutoff — every city *just* over the threshold has a leading 5). This is the canonical example: real geographic data spanning many orders of magnitude (~$10^3$ to $10^7$), drawn from the same multiplicative growth process across continents.
+
+**Fibonacci numbers.** $F_1, \ldots, F_{1000}$, computed via Binet's closed form. The first-digit distribution is *exactly* Benford in the limit: Weyl's equidistribution theorem says the sequence $n \log_{10}(\varphi) \bmod 1$ is equidistributed on $[0, 1)$, and §3 will turn that into the Benford PMF directly. Even at $n = 1000$ the empirical fit is within ~4 % per cell.
+
+**Adult heights.** Synthetic, $n = 10{,}000$, $\mathcal{N}(170, 10)$ centimetres. *Not* Benford: the data span less than one order of magnitude (most values lie between 150 and 190 cm), so the leading-digit distribution collapses to "almost everything starts with 1". $\hat P(1) > 0.55$, several digits absent entirely. This is the negative control — the class of data Benford explicitly does not apply to.
+
+The three curves capture the operating range. Benford appears wherever the data span several orders of magnitude *multiplicatively*. It fails where the data live on an additive scale of similar quantities (heights, IQ scores, exam grades). The next two sections derive the mathematical reason for this divide.
+
+---
+
+## 3. First derivation: the mantissa is uniform on $[0, 1)$
+
+Write any positive real $X$ in scientific notation:
+
+$$
+X = r \cdot 10^k, \qquad r \in [1, 10), \quad k \in \mathbb{Z}.
+$$
+
+The factor $r$ is the **mantissa** and $k$ is the order of magnitude. The first significant digit of $X$ is just $\lfloor r \rfloor$. Take logarithms:
+
+$$
+\log_{10}(X) = \log_{10}(r) + k, \qquad \log_{10}(r) \in [0, 1).
+$$
+
+Define the **log-mantissa** $Y = \log_{10}(X) \bmod 1$. By construction $Y \in [0, 1)$, and the first digit of $X$ is determined by which subinterval of $[0, 1)$ contains $Y$:
+
+$$
+D(X) = d \iff \log_{10}(d) \le Y < \log_{10}(d + 1).
+$$
+
+So far this is bookkeeping. The probabilistic premise is the next sentence.
+
+> **Premise (log-uniform mantissa).** $Y \sim \mathrm{Uniform}(0, 1)$.
+
+If we accept this, the first-digit distribution falls out of one line:
+
+$$
+P(D = d) \;=\; \Pr[\log_{10}(d) \le Y < \log_{10}(d + 1)] \;=\; \log_{10}(d + 1) - \log_{10}(d) \;=\; \log_{10}\!\left(1 + \frac{1}{d}\right).
+$$
+
+That is the entire derivation.
+
+![Mantissa-uniformity intuition.](../figures/log_uniform_intuition.png)
+
+The substantive question is *why* the premise should hold. Three arguments:
+
+**Multiplicative processes.** Many natural quantities are products of independent factors: a city's population at year $t$ is $p_0 \prod_i (1 + r_i)$ for growth rates $r_i$. Taking logs turns the product into a sum, and the central limit theorem makes $\log_{10}(X)$ approximately Gaussian — but with a variance that grows with the number of factors. As the variance grows, the *fractional part* $Y$ approaches uniform on $[0, 1)$ regardless of where the mean sits. Most of Benford's twenty datasets are multiplicative in this sense.
+
+**Equidistribution.** For a deterministic sequence like $X_n = a^n$ with $\log_{10}(a)$ irrational, Weyl's equidistribution theorem says $\{n \log_{10}(a)\} \bmod 1$ is equidistributed on $[0, 1)$. The first-digit empirical distribution converges *exactly* to Benford. Fibonacci is the cleanest example: $F_n \sim \varphi^n / \sqrt{5}$, and $\log_{10}(\varphi)$ is irrational.
+
+**Measure-theoretic uniqueness.** Translation-invariant probability measures on the circle $\mathbb{R}/\mathbb{Z}$ are unique up to normalisation (Haar measure). Section 4 turns this remark into Pinkham's derivation.
+
+The premise is *load-bearing*: if the log-mantissa is not uniform, the first-digit distribution is whatever follows from the actual density of $Y$. A Gaussian $X$ centred at $\log_{10}(170) \approx 2.23$ — adult heights in centimetres — produces a $Y$-density sharply peaked near $0.23$, which corresponds to a first digit pinned at $1$. The 55 % leading-1 frequency in §2's heights dataset is exactly this effect made visible.
+
+So the first derivation answers the question "*given* a log-uniform mantissa, what is the first-digit law?" — but not "*why* should the mantissa be log-uniform?" That is the gap Pinkham closes.
+
+---
+
+## 4. Second derivation: scale invariance forces $1/x$
+
+Currency is the cleanest motivation. Take a dataset of revenues in BRL. Convert to USD by multiplying every entry by some exchange rate $c$. The leading-digit distribution should not change just because we relabelled the unit. Formally:
+
+> **Scale invariance.** $\Pr[D(cX) = d] = \Pr[D(X) = d]$ for every $c > 0$ and every $d \in \{1, \ldots, 9\}$.
+
+This is a strong constraint. It rules out, for example, the uniform distribution on digits — uniform under one currency will not be uniform after multiplying every value by $\pi$.
+
+Take logs again. With $Y = \log_{10}(X) \bmod 1$ and $\alpha = \log_{10}(c) \bmod 1$, the multiplication $X \mapsto cX$ acts on $Y$ as a translation:
+
+$$
+Y \;\mapsto\; (Y + \alpha) \bmod 1.
+$$
+
+The set of attainable $\alpha$ as $c$ ranges over $(0, \infty)$ is the entire interval $[0, 1)$. So scale invariance is *equivalent* to translation invariance of $Y$ on the circle $\mathbb{R}/\mathbb{Z}$. And there is exactly one translation-invariant probability distribution on the circle: the uniform distribution.
+
+Scale invariance therefore forces $Y \sim \mathrm{Uniform}(0, 1)$, which by §3 forces the Benford PMF. The argument is clean enough to deserve a name; it is **Pinkham's theorem**.
+
+There is a complementary route through the *density* rather than the log-mantissa. On a finite window $[a, b] \subset (0, \infty)$ the only probability density invariant under multiplication is
+
+$$
+f(x) = \frac{1}{x \log(b/a)}.
+$$
+
+Restricting to $[10^k, 10^{k+1})$,
+
+$$
+P(D = d) = \int_{d \cdot 10^k}^{(d+1) \cdot 10^k} \frac{1}{x \ln 10}\, dx = \log_{10}\!\left(1 + \frac{1}{d}\right).
+$$
+
+The factor $10^k$ cancels. That cancellation *is* the scale invariance, made arithmetic.
+
+![Multiplying world city populations by various constants. The first-digit distribution does not move.](../figures/scale_invariance.png)
+
+Two corollaries worth flagging:
+
+**Base invariance.** Repeating the derivation in base $b > 1$ gives $P_b(d) = \log_b(1 + 1/d)$ for $d \in \{1, \ldots, b-1\}$. In octal, $P_8(1) = \log_8 2 = 1/3$, slightly more than the decimal $P_{10}(1) \approx 0.301$. Same shape, different support. The choice of base 10 is a notational artefact; the law is structural.
+
+**Why two derivations matter.** §3 starts from a probabilistic premise (log-uniform mantissa) and lands on $\log_{10}(1 + 1/d)$. §4 starts from a structural premise (no preferred unit) and lands on $\log_{10}(1 + 1/d)$. §4 *implies* §3's premise, so the two are not literally independent — but they are *structurally* different. The fact that two unrelated assumptions converge on the same formula is the strongest evidence that the law is not an empirical accident.
+
+The next question is operational: given a real dataset, how do we *test* whether it conforms?
+
+---
+
+## 5. Testing conformity: $\chi^2$, KS, MAD, $Z$
+
+Four tests, four sensitivities. Take an empirical first-digit distribution $\hat P(1), \ldots, \hat P(9)$ on a sample of size $n$, and ask: how close is it to the Benford PMF?
+
+![The four-test bundle on three reference datasets.](../figures/conformity_test_demo.png)
+
+**Pearson $\chi^2$.** Treat the count vector $(O_1, \ldots, O_9)$ as multinomial with parameters $(n; P(1), \ldots, P(9))$ under the null. The test statistic
+
+$$
+\chi^2 = \sum_{d=1}^{9} \frac{(O_d - n P(d))^2}{n P(d)}
+$$
+
+is asymptotically $\chi^2_8$ — the constraint $\sum_d O_d = n$ removes one degree of freedom from the nine cells. Reject at $\alpha = 0.05$ if $\chi^2 > 15.51$. Chi-squared is the honest hypothesis test for moderate $n$, but it has a known defect: at very large $n$ ($\sim 10^6$), even microscopic deviations (~0.001 per cell) become "statistically significant". The test answers the question "is the deviation literally zero?", which is rarely the question of interest in practice.
+
+**Kolmogorov–Smirnov.** $D_n = \max_d |F_n(d) - F(d)|$, where $F$ is the cumulative Benford CDF. Sensitive to *systematic* drift across the cells in a way $\chi^2$ averages away. The asymptotic Kolmogorov distribution gives a p-value via $\sqrt{n}\, D_n$, but it is conservative on a discrete distribution — useful as a diagnostic, not as a sharp test.
+
+**MAD with Nigrini's thresholds.** The simplest statistic, $\mathrm{MAD} = \tfrac{1}{9} \sum_d |\hat P(d) - P(d)|$, is **sample-size invariant**: a given proportion vector yields the same value at $n = 1{,}000$ or $n = 10^7$. Mark Nigrini's *Benford's Law* (Wiley, 2012) calibrates a verdict scale: $< 0.006$ "close conformity"; $< 0.012$ "acceptable"; $< 0.015$ "marginally acceptable"; $\ge 0.015$ "non-conformity". MAD has no formal sampling distribution and no p-value — but it is the only one of the four that scales sensibly to forensic-audit datasets where $n \gg 10^5$.
+
+**Per-digit $Z$.** For each $d$, treat $O_d \sim \mathrm{Binomial}(n, P(d))$ and compute the standardized two-sided $z_d$ (with Yates' continuity correction). Reject at $\alpha = 0.05$ if $|z_d| > 1.96$. Per-digit $Z$ does not control the family-wise error rate across the nine cells — it is a *diagnostic*: if cell 1 alone is flagged, the data are short of leading 1s; if $\{8, 9\}$ are flagged, the data show round-number bias.
+
+The rule for choosing among the four:
+
+| Question | Test |
+|---|---|
+| Honest hypothesis test, moderate $n$ | $\chi^2$ |
+| Cumulative drift across cells | KS |
+| Forensic-scale audit, $n \gg 10^5$ | MAD |
+| *Which* digit is off? | per-digit $Z$ |
+
+In practice, run all four. The implementation is `src.conformity.conformity_report`.
+
+---
+
+## 6. Fraud demo: when fabricated numbers betray themselves
+
+Phase 5 closes the loop. Take a clean Benford-conforming dataset, replace a fraction of its entries with fabricated values, and watch the four-test bundle cross from *accept* to *reject*.
+
+![Clean vs 30%-contaminated city populations.](../figures/fraud_before_after.png)
+
+The fabricated batch is calibrated to look superficially plausible: drawn over the same magnitude window as the original data, so the fraud signal lives in the *digit distribution* and not in the order of magnitude. Three fabrication strategies are implemented in `src.fraud`:
+
+1. **Uniform-digit.** Each leading digit appears ~11.1 %. The textbook violation.
+2. **Round numbers.** Values cluster at $100, 200, 250, 500, 1{,}000, 2{,}000, 5{,}000, 10{,}000$, mimicking the fraudster who rounds mentally.
+3. **Psychological.** Humans asked to write "random" numbers over-pick the mid digits 3–6 and under-pick 1 and 9.
+
+Sweeping the contamination fraction from 0 % to 100 % and running the four-test bundle 30 times at each level gives the **detection-power curve**:
+
+![Detection power across three fabrication strategies on the GeoNames cities5000 dataset.](../figures/fraud_detection_power.png)
+
+The MAD curve climbs through Nigrini's verdict tiers (acceptable → marginally acceptable → non-conformity) within the first 5–10 % of contamination. The Pearson $\chi^2$ statistic — log-scale — climbs steeply through its $\alpha = 0.05$ critical value of 15.51 at roughly the same point. The empirical rejection rate at $\alpha = 0.05$ saturates near 1 for all three fabrication kinds by 10–15 % contamination.
+
+The reading: at this sample size, a Benford-style audit reliably detects fraud whenever 10 % or more of the entries are fabricated by any of the three strategies. Below 5 %, detection power varies — round-number fabrication is the hardest to catch because it preserves the leading-digit bias of Benford while displacing it onto $\{1, 2, 5\}$.
+
+This experiment is not just a toy. Documented historical cases include:
+
+- **Greek fiscal statistics (2010).** Rauch, Göttsche, Brähler & Engel (2011, *German Economic Review*) applied first-digit analysis to EU member-state macroeconomic deficit reports for 1999–2009 and found Greece the only state whose deficit reports significantly violated Benford's Law — published months before official acknowledgment of statistical manipulation.
+- **2009 Iranian presidential election.** Multiple post-hoc analyses (Mebane and follow-up work) found anomalies consistent with Benford-style irregularities at the polling-station level.
+- **Forensic accounting.** Mark Nigrini's *Benford's Law* (2012) is the practitioner's textbook, applied across thousands of corporate datasets.
+
+The script `scripts/exp_fraud_demo.py` reproduces the *mechanism* by which these audits work: under the null, the empirical first-digit distribution sits on top of the Benford curve; contamination pushes it off, and the conformity tests measure the push.
+
+---
+
+## 7. When Benford fails, and why that is also useful
+
+Benford's Law is not a universal law of numbers. It applies to datasets whose values span several orders of magnitude *multiplicatively* and are generated by a process that mixes scales. It fails — sharply — for at least three classes of data:
+
+1. **Bounded data on an additive scale.** Adult heights, body temperatures, IQ scores, exam grades. The values sit within one order of magnitude, so the log-mantissa $Y$ is sharply concentrated and the first-digit distribution collapses to whatever digit dominates the support. §2's heights example is the textbook case.
+
+2. **Assigned identifiers.** Phone numbers, ZIP codes, social security numbers, ID document numbers. These are sampled from a fixed combinatorial design, not generated by a multiplicative process; the leading digit is a structural artefact of the issuing authority.
+
+3. **Truncated data.** Any dataset with a hard floor or ceiling distorts the leading-digit distribution near the cutoff. The GeoNames `cities5000` data show a small spike at $d = 5$ for exactly this reason — every city *just* over the 5,000-population threshold has a leading 5.
+
+The failures are operationally useful. A dataset that *should* conform to Benford and does not is a flag: either the data-generating process is not what you thought, or the data have been tampered with. Forensic accounting uses this asymmetrically — a Benford-conforming dataset is uninformative; a Benford-failing dataset is the question worth asking.
+
+---
+
+## 8. Takeaways
+
+1. **The Benford PMF $P(d) = \log_{10}(1 + 1/d)$ is structural, not coincidental.** Two unrelated derivations — log-uniform mantissa and scale invariance — converge on the same curve. The convergence is the evidence.
+
+2. **Scale invariance is the deeper reason.** Pinkham's argument shows that any unit-independent leading-digit law *must* be the Benford curve. Newcomb's mantissa heuristic is a corollary of the stronger statement, not an independent fact.
+
+3. **Conformity is testable, with four complementary statistics.** Pearson $\chi^2$ for honest hypothesis tests; KS for cumulative drift; MAD with Nigrini's thresholds for forensic-scale audits ($n \gg 10^5$); per-digit $Z$ to localise *which* digit is off. Run all four.
+
+4. **Fraud detection is the cleanest application.** With the GeoNames cities dataset at $n \approx 68{,}000$, the Benford bundle reliably flags 10 %-or-more contamination by any of the three fabrication strategies tested.
+
+5. **Benford fails on bounded, additive, or assigned data.** The failures are operationally useful: a dataset that *should* conform and doesn't is the one worth investigating.
+
+The code, derivations, exercises, and figures are in the companion repository: <https://github.com/brunoramosmartins/benford-law-til>.
+
+---
+
+## References
+
+- **Newcomb, S.** (1881). Note on the frequency of use of the different digits in natural numbers. *American Journal of Mathematics*, **4**(1), 39–40.
+- **Benford, F.** (1938). The law of anomalous numbers. *Proceedings of the American Philosophical Society*, **78**(4), 551–572.
+- **Pinkham, R. S.** (1961). On the distribution of first significant digits. *Annals of Mathematical Statistics*, **32**(4), 1223–1230.
+- **Hill, T. P.** (1995). A statistical derivation of the significant-digit law. *Statistical Science*, **10**(4), 354–363.
+- **Nigrini, M. J.** (2012). *Benford's Law: Applications for Forensic Accounting, Auditing, and Fraud Detection*. Wiley.
+- **Berger, A. & Hill, T. P.** (2015). *An Introduction to Benford's Law*. Princeton University Press.
+- **Rauch, B., Göttsche, M., Brähler, G. & Engel, S.** (2011). Fact and fiction in EU-governmental economic data. *German Economic Review*, **12**(3), 243–255.


### PR DESCRIPTION
## Summary

Closes Phase 6. Full ~3,250-word TIL article in 8 sections, plus a
PT-BR mirror for review.

- `article/benford-law-til.md` — canonical English version (~3,215 words)
- `article/benford-law-til-pt-BR.md` — PT-BR review copy, same structure

Sections: (1) worn logarithm-table pages, (2) empirical Benford in
three datasets, (3) first derivation (log-uniform mantissa), (4)
second derivation (scale invariance via Pinkham), (5) four-test
conformity bundle, (6) fraud demo with detection-power curve, (7)
when Benford fails, (8) takeaways. References include Newcomb (1881),
Benford (1938), Pinkham (1961), Hill (1995), Nigrini (2012), Berger &
Hill (2015), Rauch et al. (2011).

All six figures from Phases 2–5 are referenced via `../figures/<name>.png`.

## Test plan

- [ ] Render `article/benford-law-til.md` on GitHub; confirm all 6
      figures resolve and LaTeX math renders cleanly.
- [ ] Read PT-BR version side-by-side with the English version;
      confirm parity of claims and figure placement.
- [ ] Spot-check word count (~3,250 target).
- [ ] Verify references list matches the in-text citations.