### PR TITLE
docs(article): Phase 6 — full TIL draft (EN + PT-BR review copy)

### DIFF
--- a/article/benford-law-til-pt-BR.md
+++ b/article/benford-law-til-pt-BR.md
@@ -152,9 +152,11 @@ A próxima pergunta é operacional: dado um conjunto de dados real, como *testam
 
 ## 5. Testando conformidade: $\chi^2$, KS, MAD, $Z$
 
-Quatro testes, quatro sensibilidades. Tome uma distribuição empírica de primeiro dígito $\hat P(1), \ldots, \hat P(9)$ em uma amostra de tamanho $n$ e pergunte: o quão próxima está da PMF de Benford?
+A lei é estrutural, mas dados reais satisfazem a premissa apenas aproximadamente — uma amostra finita nunca pousa exatamente sobre a curva de Benford, e mesmo conjuntos com várias décadas de cobertura carregam uma ondulação residual. Resta portanto uma pergunta empírica: quão próximo é próximo o suficiente para chamarmos os dados de conformes, e que tipo de desvio nos preocupa? Audiências diferentes querem distâncias diferentes — quem testa hipótese quer um p-valor, quem audita quer uma escala de veredito que não colapse em tamanhos industriais de amostra, quem investiga quer saber *qual* dígito está fora. Nenhuma estatística sozinha responde aos três, então a prática padrão é rodar um pequeno bundle. Quatro testes, quatro sensibilidades. Tome uma distribuição empírica de primeiro dígito $\hat P(1), \ldots, \hat P(9)$ em uma amostra de tamanho $n$ e pergunte: o quão próxima está da PMF de Benford (a função massa de probabilidade $P(d) = \log_{10}(1 + 1/d)$, $d = 1, \ldots, 9$)?
 
-![O bundle dos quatro testes em três conjuntos de referência.](../figures/conformity_test_demo.png)
+![Três conjuntos de referência — populações de cidades, Fibonacci, alturas adultas — com os vereditos dos quatro testes reportados no título de cada painel.](../figures/conformity_test_demo.png)
+
+A figura é o catálogo: três conjuntos de referência (um real e conforme, um sintético e conforme, um sintético que falha), cada painel carregando *os quatro* vereditos no título. São três painéis, não quatro — um por dataset; os quatro testes aparecem por painel. O layout espelha como o bundle é usado na prática: um conjunto de dados, quatro números, um veredito.
 
 **$\chi^2$ de Pearson.** Trate o vetor de contagens $(O_1, \ldots, O_9)$ como multinomial com parâmetros $(n; P(1), \ldots, P(9))$ sob a hipótese nula. A estatística
 
@@ -162,15 +164,15 @@ $$
 \chi^2 = \sum_{d=1}^{9} \frac{(O_d - n P(d))^2}{n P(d)}
 $$
 
-é assintoticamente $\chi^2_8$ — a restrição $\sum_d O_d = n$ remove um grau de liberdade das nove células. Rejeita-se em $\alpha = 0{,}05$ se $\chi^2 > 15{,}51$. O qui-quadrado é o teste de hipótese honesto para $n$ moderado, mas tem uma falha conhecida: para $n$ muito grande (da ordem de $10^6$), até desvios microscópicos (em torno de $0{,}001$ por célula) tornam-se "estatisticamente significativos". O teste responde "o desvio é literalmente zero?", o que raramente é a pergunta de interesse na prática.
+é assintoticamente $\chi^2_8$ — a restrição $\sum_d O_d = n$ remove um grau de liberdade das nove células. Rejeita-se em $\alpha = 0{,}05$ se $\chi^2 > 15{,}51$. O qui-quadrado é o teste de hipótese honesto para $n$ moderado, mas tem uma falha conhecida: para $n$ muito grande (da ordem de $10^6$), até desvios microscópicos (em torno de $0{,}001$ por célula) tornam-se "estatisticamente significativos". O teste responde "o desvio é literalmente zero?", o que raramente é a pergunta de interesse na prática. Essa falha motiva as duas estatísticas seguintes.
 
-**Kolmogorov–Smirnov.** $D_n = \max_d |F_n(d) - F(d)|$, onde $F$ é a CDF cumulativa de Benford. Sensível a *deriva sistemática* ao longo das células de modo que o $\chi^2$ dilui na média. A distribuição assintótica de Kolmogorov fornece um p-valor via $\sqrt{n}\, D_n$, mas é conservadora numa distribuição discreta — útil como diagnóstico, não como teste afiado.
+**Kolmogorov–Smirnov.** $D_n = \max_d |F_n(d) - F(d)|$, onde $F$ é a CDF cumulativa de Benford. Sensível a *deriva sistemática* ao longo das células de modo que o $\chi^2$ dilui na média — se o desvio é concentrado num degrau ou numa rampa em vez de espalhado, o KS percebe e o $\chi^2$ pode não perceber. A distribuição assintótica de Kolmogorov fornece um p-valor via $\sqrt{n}\, D_n$, mas é conservadora numa distribuição discreta — útil como diagnóstico, não como teste afiado. O KS ainda herda o problema de inflação para $n$ grande, e é isso que o MAD endereça.
 
-**MAD com limiares de Nigrini.** A estatística mais simples, $\mathrm{MAD} = \tfrac{1}{9} \sum_d |\hat P(d) - P(d)|$, é **invariante ao tamanho da amostra**: um vetor de proporções produz o mesmo valor para $n = 1{.}000$ ou $n = 10^7$. *Benford's Law* (Wiley, 2012) de Mark Nigrini calibra uma escala de veredito: $< 0{,}006$ "conformidade próxima"; $< 0{,}012$ "aceitável"; $< 0{,}015$ "marginalmente aceitável"; $\ge 0{,}015$ "não-conformidade". MAD não tem distribuição amostral formal nem p-valor — mas é o único dos quatro que escala razoavelmente para dados de auditoria forense onde $n \gg 10^5$.
+**MAD com limiares de Nigrini.** A estatística mais simples, $\mathrm{MAD} = \tfrac{1}{9} \sum_d |\hat P(d) - P(d)|$, é **invariante ao tamanho da amostra**: um vetor de proporções produz o mesmo valor para $n = 1{.}000$ ou $n = 10^7$. *Benford's Law* (Wiley, 2012) de Mark Nigrini calibra uma escala de veredito: $< 0{,}006$ "conformidade próxima"; $< 0{,}012$ "aceitável"; $< 0{,}015$ "marginalmente aceitável"; $\ge 0{,}015$ "não-conformidade". MAD não tem distribuição amostral formal nem p-valor — mas é o único dos quatro que escala razoavelmente para dados de auditoria forense onde $n \gg 10^5$. O preço é que o MAD agrega sobre as nove células, então não diz *onde* mora o desvio — esse é o trabalho do último teste.
 
 **$Z$ por dígito.** Para cada $d$, trate $O_d \sim \mathrm{Binomial}(n, P(d))$ e calcule o $z_d$ bilateral padronizado (com correção de continuidade de Yates). Rejeita-se em $\alpha = 0{,}05$ se $|z_d| > 1{,}96$. O $Z$ por dígito não controla a taxa de erro familiar entre as nove células — é um *diagnóstico*: se só a célula 1 é sinalizada, faltam 1s iniciais nos dados; se as células 8 e 9 são sinalizadas, os dados mostram viés de números redondos.
 
-A regra para escolher entre os quatro:
+Cada teste responde a uma pergunta diferente, então a regra para escolher é casar a pergunta com o teste:
 
 | Pergunta | Teste |
 |---|---|
@@ -179,7 +181,7 @@ A regra para escolher entre os quatro:
 | Auditoria em escala forense, $n \gg 10^5$ | MAD |
 | *Qual* dígito está fora? | $Z$ por dígito |
 
-Na prática, rode os quatro. A implementação está em `src.conformity.conformity_report`.
+Na prática, rode os quatro — eles custam quase nada após calcular $\hat P$ uma vez, e cada um pega um tipo de desvio que os outros perdem. A implementação está em `src.conformity.conformity_report`.
 
 ---
 

--- a/article/benford-law-til-pt-BR.md
+++ b/article/benford-law-til-pt-BR.md
@@ -84,7 +84,7 @@ $$
 
 Essa é toda a derivação. O que parece um truque é estrutural: ao trocar a coordenada multiplicativa $X$ pela coordenada aditiva $Y$, transformamos a pergunta "qual é o primeiro dígito?" numa pergunta sobre comprimentos no círculo $[0, 1)$, e probabilidade uniforme nesse círculo se traduz diretamente na curva logarítmica.
 
-A figura abaixo torna o argumento tangível em dois movimentos. Na linha de cima, o histograma da log-mantissa $Y$ para amostras sintéticas $X = 10^U$ com $U \sim \mathrm{Uniforme}(0, k)$ é mostrado para $k = 0{,}5,\, 1{,}5,\, 3{,}5,\, 8{,}5$ — valores deliberadamente não-inteiros, para que a convergência seja visível. Em $k = 0{,}5$, $Y$ nem cobre $[0, 1)$ (toda a massa está em $[0; 0{,}5)$); em $k = 1{,}5$, há um degrau claro em $Y = 0{,}5$ (densidade $\approx 1{,}33$ na primeira metade contra $\approx 0{,}67$ na segunda); em $k = 3{,}5$ o degrau é mais brando; em $k = 8{,}5$ o histograma é visualmente plano. A diferença em relação à uniforme decai como $1/k$. Na linha de baixo, as frequências de primeiro dígito da amostra sintética com $k = 8{,}5$ (esquerda) e das populações de cidades do mundo (direita) assentam sobre a PMF de Benford: a premissa implica a curva, e dados reais multiescalares satisfazem a premissa.
+A figura abaixo torna o argumento tangível em dois movimentos. Na linha de cima, o histograma da log-mantissa $Y$ para amostras sintéticas $X = 10^U$ com $U \sim \mathrm{Uniforme}(0, k)$ é mostrado para $k = 0{,}5,\, 1{,}5,\, 3{,}5,\, 8{,}5$ — valores deliberadamente não-inteiros, para que a convergência seja visível. Em $k = 0{,}5$, $Y$ nem cobre todo o intervalo unitário — a massa fica concentrada na primeira metade ($Y < 0{,}5$) com densidade $2$, e a segunda metade está vazia; em $k = 1{,}5$, $Y$ já cobre o intervalo todo, mas com um degrau claro em $Y = 0{,}5$ (densidade $\approx 1{,}33$ na primeira metade contra $\approx 0{,}67$ na segunda); em $k = 3{,}5$ o degrau é mais brando; em $k = 8{,}5$ o histograma é visualmente plano. A diferença em relação à uniforme decai como $1/k$. Na linha de baixo, as frequências de primeiro dígito da amostra sintética com $k = 8{,}5$ (esquerda) e das populações de cidades do mundo (direita) assentam sobre a PMF de Benford: a premissa implica a curva, e dados reais multiescalares satisfazem a premissa.
 
 ![Linha de cima: a log-mantissa Y converge à densidade uniforme conforme X cobre mais décadas (k = 0,5; 1,5; 3,5; 8,5). Linha de baixo: o primeiro dígito segue Benford, em dados sintéticos à esquerda e reais à direita.](../figures/log_uniform_intuition.png)
 
@@ -104,7 +104,7 @@ Logo a primeira derivação responde à pergunta "*dada* uma mantissa log-unifor
 
 ## 4. Segunda derivação: invariância de escala força $1/x$
 
-Moeda é a motivação mais limpa. Tome um conjunto de receitas em BRL. Converta para USD multiplicando cada entrada por alguma taxa de câmbio $c$. A distribuição de primeiro dígito não deveria mudar só porque rotulamos a unidade de outra forma. Formalmente:
+Moeda é a motivação mais limpa. Tome um conjunto de receitas em BRL. Converta para USD multiplicando cada entrada por alguma taxa de câmbio $c$. A distribuição de primeiro dígito não deveria mudar só porque rotulamos a unidade de outra forma — o dólar e o real são apenas etiquetas, e a atividade econômica subjacente não sabe qual escolhemos. Essa expectativa informal é uma afirmação de *simetria* sobre os dados, não uma afirmação estatística. Formalmente:
 
 **Invariância de escala.** Para todo $c > 0$ e todo dígito $d$ de $1$ a $9$,
 
@@ -112,19 +112,19 @@ $$
 \Pr[D(cX) = d] = \Pr[D(X) = d].
 $$
 
-É uma restrição forte. Exclui, por exemplo, a distribuição uniforme nos dígitos — uniforme em uma moeda não será uniforme depois de multiplicar cada valor por $\pi$.
+É uma restrição forte. Exclui, por exemplo, a distribuição uniforme nos dígitos — uniforme em uma moeda não será uniforme depois de multiplicar cada valor por $\pi$. Antes mesmo de qualquer derivação, o requisito já restringe sensivelmente as distribuições candidatas.
 
-Tome logaritmos novamente. Com $Y = \log_{10}(X) \bmod 1$ e $\alpha = \log_{10}(c) \bmod 1$, a multiplicação $X \mapsto cX$ age sobre $Y$ como uma translação:
+O movimento natural é passar de novo aos logaritmos, porque o logaritmo transforma multiplicação em soma. Com $Y = \log_{10}(X) \bmod 1$ e $\alpha = \log_{10}(c) \bmod 1$, a operação $X \mapsto cX$ vira $\log_{10}(X) \mapsto \log_{10}(X) + \log_{10}(c)$, o que na log-mantissa é uma translação:
 
 $$
 Y \mapsto (Y + \alpha) \bmod 1.
 $$
 
-O conjunto de $\alpha$ atingíveis enquanto $c$ percorre $(0, \infty)$ é o intervalo $[0, 1)$ inteiro. Logo invariância de escala é *equivalente* a invariância por translação de $Y$ no círculo $\mathbb{R}/\mathbb{Z}$. E existe exatamente uma distribuição de probabilidade invariante por translação no círculo: a uniforme.
+Conforme $c$ percorre $(0, \infty)$, $\log_{10}(c)$ percorre todo o $\mathbb{R}$, então $\alpha = \log_{10}(c) \bmod 1$ assume todo valor em $[0, 1)$. Invariância de escala em $X$ é portanto *equivalente* a invariância por translação de $Y$ no círculo $\mathbb{R}/\mathbb{Z}$. E existe exatamente uma distribuição de probabilidade invariante por translação no círculo: a uniforme. A intuição é de simetria — qualquer outra distribuição teria um "ponto preferido" que a translação deslocaria, contradizendo a invariância. (Formalmente, é a unicidade da medida de Haar em um grupo compacto.)
 
 Invariância de escala portanto força $Y \sim \mathrm{Uniforme}(0, 1)$, o que pela §3 força a PMF de Benford. O argumento é limpo o suficiente para merecer um nome; é o **teorema de Pinkham**.
 
-Há uma rota complementar pela *densidade* em vez de pela log-mantissa. Em uma janela finita $[a, b] \subset (0, \infty)$ a única densidade de probabilidade invariante por multiplicação é
+Uma rota complementar trabalha diretamente com a *densidade* sobre $X$, sem passar pela log-mantissa, e vale a pena ver porque torna explícita a forma $1/x$. Sob $X \mapsto cX$ uma densidade de probabilidade se transforma como $f(x) \mapsto \frac{1}{c} f(x/c)$. Exigir que isso seja igual a $f(x)$ para todo $c > 0$ força $f(x) \propto 1/x$. Assim, em uma janela finita $[a, b] \subset (0, \infty)$ a única densidade de probabilidade invariante por multiplicação é
 
 $$
 f(x) = \frac{1}{x \log(b/a)}.
@@ -136,7 +136,7 @@ $$
 P(D = d) = \int_{d \cdot 10^k}^{(d+1) \cdot 10^k} \frac{1}{x \ln 10}\, dx = \log_{10}\left(1 + \frac{1}{d}\right).
 $$
 
-O fator $10^k$ cancela. Esse cancelamento *é* a invariância de escala, em forma aritmética.
+O fator $10^k$ cancela. Esse cancelamento *é* a invariância de escala, em forma aritmética: a probabilidade do primeiro dígito não depende de qual década restringimos.
 
 ![Multiplicando populações de cidades por várias constantes. A distribuição de primeiro dígito não se mexe.](../figures/scale_invariance.png)
 

--- a/article/benford-law-til-pt-BR.md
+++ b/article/benford-law-til-pt-BR.md
@@ -187,23 +187,25 @@ Na prática, rode os quatro — eles custam quase nada após calcular $\hat P$ u
 
 ## 6. Demo de fraude: quando números fabricados se entregam
 
-A Fase 5 fecha o ciclo. Pegue um conjunto limpo, conforme a Benford, substitua uma fração de suas entradas por valores fabricados e veja o bundle dos quatro testes cruzar de *aceitar* para *rejeitar*.
+A §5 montou o bundle de conformidade em dados limpos; a §6 o coloca para trabalhar em cenário adversarial. Pegue um conjunto limpo, conforme a Benford, substitua uma fração de suas entradas por valores fabricados e veja o bundle dos quatro testes cruzar de *aceitar* para *rejeitar*. O setup é deliberadamente estilizado — não há fraudador real do outro lado, e controlamos tudo — mas é a forma mais limpa de ver que tipo de contaminação o bundle pega e o que deixa passar. O ponto não é provar que o bundle funciona; é ler onde fica o seu limiar.
 
 ![Populações de cidades limpas vs contaminadas a 30 %.](../figures/fraud_before_after.png)
 
-A leva fabricada é calibrada para parecer superficialmente plausível: amostrada na mesma janela de magnitude dos dados originais, de modo que o sinal de fraude vive na *distribuição de dígitos* e não na ordem de grandeza. Três estratégias de fabricação estão implementadas em `src.fraud`:
+A figura antes-e-depois mostra o mesmo conjunto GeoNames `cities5000` ($n \approx 68{.}000$) antes da contaminação, à esquerda, e depois de substituir 30 % das entradas por valores fabricados, à direita. A curva de Benford não se mexe; o que se mexe são as barras empíricas, e o bundle lê a distância.
 
-1. **Dígito uniforme.** Cada dígito inicial aparece em cerca de $11{,}1\,\%$ das entradas. A violação de manual.
-2. **Números redondos.** Valores se concentram em $100, 200, 250, 500, 1{.}000, 2{.}000, 5{.}000, 10{.}000$, imitando o fraudador que arredonda mentalmente.
-3. **Psicológica.** Humanos pedidos para escrever números "aleatórios" superestimam os dígitos médios 3–6 e subestimam 1 e 9.
+A leva fabricada é calibrada para parecer superficialmente plausível: amostrada na mesma janela de magnitude dos dados originais, de modo que o sinal de fraude vive na *distribuição de dígitos* e não na ordem de grandeza. Este é o modelo de ameaça realista — um fraudador que acerta a escala e erra os dígitos, não um que inventa receitas de nove dígitos para uma pequena empresa. Três estratégias de fabricação estão implementadas em `src.fraud`:
 
-Varrendo a fração de contaminação de 0 % a 100 % e rodando o bundle dos quatro testes 30 vezes em cada nível obtém-se a **curva de poder de detecção**:
+1. **Dígito uniforme.** Cada dígito inicial aparece em cerca de $11{,}1\,\%$ das entradas. A violação de manual — a mais fácil de pegar porque embaralha a curva inteira de uma vez.
+2. **Números redondos.** Valores se concentram em $100, 200, 250, 500, 1{.}000, 2{.}000, 5{.}000, 10{.}000$, imitando o fraudador que arredonda mentalmente. Sutil, porque números redondos preservam um viés de dígito inicial próprio.
+3. **Psicológica.** Humanos pedidos para escrever números "aleatórios" superestimam os dígitos médios 3–6 e subestimam 1 e 9 — um viés cognitivo reproduzível, documentado na literatura experimental.
+
+Cada estratégia é um ataque distinto à curva, e cada uma submete o bundle a um teste de estresse diferente. Para condensar isso numa única imagem de poder de detecção, varra a fração de contaminação de 0 % a 100 % e rode o bundle dos quatro testes 30 vezes em cada nível. O resultado é a **curva de poder de detecção**:
 
 ![Poder de detecção em três estratégias de fabricação no GeoNames cities5000.](../figures/fraud_detection_power.png)
 
 A curva MAD sobe pelos níveis de veredito de Nigrini (aceitável → marginalmente aceitável → não-conformidade) dentro dos primeiros 5–10 % de contaminação. A estatística $\chi^2$ de Pearson — em escala logarítmica — sobe íngreme através do seu valor crítico $\alpha = 0{,}05$ de 15,51 mais ou menos no mesmo ponto. A taxa empírica de rejeição em $\alpha = 0{,}05$ satura próxima de 1 para as três estratégias por volta de 10–15 % de contaminação.
 
-A leitura: nesse tamanho amostral, uma auditoria estilo Benford detecta de modo confiável fraude sempre que 10 % ou mais das entradas forem fabricadas por qualquer das três estratégias. Abaixo de 5 %, o poder de detecção varia — fabricação por números redondos é a mais difícil de pegar porque preserva o viés de dígito inicial de Benford ao mesmo tempo em que o desloca para os dígitos $1$, $2$ e $5$.
+A leitura: nesse tamanho amostral, uma auditoria estilo Benford detecta de modo confiável fraude sempre que 10 % ou mais das entradas forem fabricadas por qualquer das três estratégias. Abaixo de 5 %, o poder de detecção varia — fabricação por números redondos é a mais difícil de pegar porque preserva o viés de dígito inicial de Benford ao mesmo tempo em que o desloca para os dígitos $1$, $2$ e $5$. O bundle não é detector mágico; é um filtro grosseiro que sinaliza a contaminação grossa de modo barato e deixa para o auditor a decisão de onde olhar mais de perto.
 
 Este experimento não é apenas um brinquedo. Casos históricos documentados incluem:
 
@@ -217,19 +219,21 @@ O script `scripts/exp_fraud_demo.py` reproduz o *mecanismo* pelo qual essas audi
 
 ## 7. Quando Benford falha, e por que isso também é útil
 
-A Lei de Benford não é uma lei universal dos números. Aplica-se a conjuntos de dados cujos valores cobrem várias ordens de magnitude *multiplicativamente* e são gerados por um processo que mistura escalas. Falha — de modo agudo — em pelo menos três classes de dados:
+A §6 mostrou o bundle pegando contaminação deliberada. Vale tornar explícito o lado oposto: Benford não é uma lei universal dos números, e existem conjuntos honestos onde ela não tem por que valer. Conhecer a fronteira é parte do uso da ferramenta — aplicar um teste Benford a dados fora da sua faixa de operação produz falsos positivos, não insight. A lei aplica-se a conjuntos cujos valores cobrem várias ordens de magnitude *multiplicativamente* e são gerados por um processo que mistura escalas. Falha — de modo agudo — em pelo menos três classes de dados:
 
-1. **Dados limitados em escala aditiva.** Alturas de adultos, temperaturas corporais, pontuações de QI, notas de prova. Os valores ficam dentro de uma ordem de magnitude, então a log-mantissa $Y$ é fortemente concentrada e a distribuição de primeiro dígito colapsa no dígito que dominar o suporte. O exemplo das alturas na §2 é o caso de manual.
+1. **Dados limitados em escala aditiva.** Alturas de adultos, temperaturas corporais, pontuações de QI, notas de prova. Os valores ficam dentro de uma ordem de magnitude, então a log-mantissa $Y$ é fortemente concentrada e a distribuição de primeiro dígito colapsa no dígito que dominar o suporte. O exemplo das alturas na §2 é o caso de manual — uma única barra alta em $d = 1$ e zeros nos demais.
 
-2. **Identificadores atribuídos.** Telefones, CEPs, números de seguro social, números de RG. São amostrados de um desenho combinatório fixo, não gerados por processo multiplicativo; o dígito inicial é um artefato estrutural da autoridade emissora.
+2. **Identificadores atribuídos.** Telefones, CEPs, números de seguro social, números de RG. São amostrados de um desenho combinatório fixo, não gerados por processo multiplicativo; o dígito inicial é um artefato estrutural da autoridade emissora, não de algum processo aleatório subjacente. Não há nada para um teste de Benford encontrar aqui, e uma "violação" diz apenas que os dados têm uma estrutura deliberada.
 
-3. **Dados truncados.** Qualquer conjunto com piso ou teto rígido distorce a distribuição de primeiro dígito perto do corte. O `cities5000` do GeoNames mostra um pequeno pico em $d = 5$ exatamente por essa razão — toda cidade *logo acima* do limiar de 5.000 habitantes tem 5 inicial.
+3. **Dados truncados.** Qualquer conjunto com piso ou teto rígido distorce a distribuição de primeiro dígito perto do corte. O `cities5000` do GeoNames mostra um pequeno pico em $d = 5$ exatamente por essa razão — toda cidade *logo acima* do limiar de 5.000 habitantes tem 5 inicial. O teste continua funcionando, mas o analista precisa saber que a truncagem está ali antes de ler o pico como fraude.
 
-As falhas são operacionalmente úteis. Um conjunto de dados que *deveria* conformar-se a Benford e não se conforma é um sinal: ou o processo gerador não é o que você pensava, ou os dados foram adulterados. A contabilidade forense usa isso assimetricamente — um conjunto conforme a Benford é não-informativo; um conjunto que falha em Benford é a pergunta que vale a pena fazer.
+As falhas são operacionalmente úteis, e a assimetria é o ponto. Um conjunto de dados que *deveria* conformar-se a Benford e não se conforma é um sinal: ou o processo gerador não é o que você pensava, ou os dados foram adulterados. A contabilidade forense usa isso assimetricamente — um conjunto conforme a Benford é não-informativo por si só; um conjunto que falha em Benford é a pergunta que vale a pena fazer. A lei é mais poderosa não quando confirma, mas quando se recusa a confirmar.
 
 ---
 
 ## 8. Conclusões
+
+Cinco pontos para fechar:
 
 1. **A PMF de Benford $P(d) = \log_{10}(1 + 1/d)$ é estrutural, não coincidência.** Duas derivações não correlacionadas — mantissa log-uniforme e invariância de escala — convergem para a mesma curva. A convergência *é* a evidência.
 

--- a/article/benford-law-til.md
+++ b/article/benford-law-til.md
@@ -146,9 +146,11 @@ The next question is operational: given a real dataset, how do we *test* whether
 
 ## 5. Testing conformity: $\chi^2$, KS, MAD, $Z$
 
-Four tests, four sensitivities. Take an empirical first-digit distribution $\hat P(1), \ldots, \hat P(9)$ on a sample of size $n$, and ask: how close is it to the Benford PMF?
+The law is structural, but real data only approximately satisfies the premise — a finite sample never sits exactly on the Benford curve, and even multi-decade datasets carry a residual ripple. So an empirical question always remains: how close is close enough to call the data conforming, and what kind of deviation are we worried about? Different audiences want different gaps — a hypothesis tester wants a p-value, an auditor wants a verdict scale that does not collapse at industrial sample sizes, a detective wants to know *which* digit is off. No single statistic answers all three, so the standard practice is to run a small bundle. Four tests, four sensitivities. Take an empirical first-digit distribution $\hat P(1), \ldots, \hat P(9)$ on a sample of size $n$ and ask: how close is it to the Benford PMF (the probability mass function $P(d) = \log_{10}(1 + 1/d)$, $d = 1, \ldots, 9$)?
 
-![The four-test bundle on three reference datasets.](../figures/conformity_test_demo.png)
+![Three reference datasets — world cities, Fibonacci, adult heights — with all four test verdicts reported in each panel's title.](../figures/conformity_test_demo.png)
+
+The figure is the catalog: three reference datasets (one real-and-conforming, one synthetic-and-conforming, one synthetic-and-failing), each panel carrying *all four* test outcomes in its title. There are three panels, not four — one per dataset; the four tests are reported per panel. The layout mirrors how the bundle is used in practice: one dataset, four numbers, one verdict.
 
 **Pearson $\chi^2$.** Treat the count vector $(O_1, \ldots, O_9)$ as multinomial with parameters $(n; P(1), \ldots, P(9))$ under the null. The test statistic
 
@@ -156,15 +158,15 @@ $$
 \chi^2 = \sum_{d=1}^{9} \frac{(O_d - n P(d))^2}{n P(d)}
 $$
 
-is asymptotically $\chi^2_8$ — the constraint $\sum_d O_d = n$ removes one degree of freedom from the nine cells. Reject at $\alpha = 0.05$ if $\chi^2 > 15.51$. Chi-squared is the honest hypothesis test for moderate $n$, but it has a known defect: at very large $n$ (on the order of $10^6$), even microscopic deviations (about $0.001$ per cell) become "statistically significant". The test answers the question "is the deviation literally zero?", which is rarely the question of interest in practice.
+is asymptotically $\chi^2_8$ — the constraint $\sum_d O_d = n$ removes one degree of freedom from the nine cells. Reject at $\alpha = 0.05$ if $\chi^2 > 15.51$. Chi-squared is the honest hypothesis test for moderate $n$, but it has a known defect: at very large $n$ (on the order of $10^6$), even microscopic deviations (about $0.001$ per cell) become "statistically significant". The test answers "is the deviation literally zero?", which is rarely the question of interest in practice. That defect is what motivates the next two statistics.
 
-**Kolmogorov–Smirnov.** $D_n = \max_d |F_n(d) - F(d)|$, where $F$ is the cumulative Benford CDF. Sensitive to *systematic* drift across the cells in a way $\chi^2$ averages away. The asymptotic Kolmogorov distribution gives a p-value via $\sqrt{n}\, D_n$, but it is conservative on a discrete distribution — useful as a diagnostic, not as a sharp test.
+**Kolmogorov–Smirnov.** $D_n = \max_d |F_n(d) - F(d)|$, where $F$ is the cumulative Benford CDF. Sensitive to *systematic* drift across the cells in a way $\chi^2$ averages away — if the deviation is concentrated as a step or a ramp rather than scattered, KS notices and $\chi^2$ may not. The asymptotic Kolmogorov distribution gives a p-value via $\sqrt{n}\, D_n$, but it is conservative on a discrete distribution — useful as a diagnostic, not as a sharp test. KS still inherits the large-$n$ inflation problem, which is what MAD addresses.
 
-**MAD with Nigrini's thresholds.** The simplest statistic, $\mathrm{MAD} = \tfrac{1}{9} \sum_d |\hat P(d) - P(d)|$, is **sample-size invariant**: a given proportion vector yields the same value at $n = 1{,}000$ or $n = 10^7$. Mark Nigrini's *Benford's Law* (Wiley, 2012) calibrates a verdict scale: $< 0.006$ "close conformity"; $< 0.012$ "acceptable"; $< 0.015$ "marginally acceptable"; $\ge 0.015$ "non-conformity". MAD has no formal sampling distribution and no p-value — but it is the only one of the four that scales sensibly to forensic-audit datasets where $n \gg 10^5$.
+**MAD with Nigrini's thresholds.** The simplest statistic, $\mathrm{MAD} = \tfrac{1}{9} \sum_d |\hat P(d) - P(d)|$, is **sample-size invariant**: a given proportion vector yields the same value at $n = 1{,}000$ or $n = 10^7$. Mark Nigrini's *Benford's Law* (Wiley, 2012) calibrates a verdict scale: $< 0.006$ "close conformity"; $< 0.012$ "acceptable"; $< 0.015$ "marginally acceptable"; $\ge 0.015$ "non-conformity". MAD has no formal sampling distribution and no p-value — but it is the only one of the four that scales sensibly to forensic-audit datasets where $n \gg 10^5$. The price is that MAD aggregates across the nine cells, so it cannot tell you *where* the deviation lives — that is the job of the last test.
 
 **Per-digit $Z$.** For each $d$, treat $O_d \sim \mathrm{Binomial}(n, P(d))$ and compute the standardized two-sided $z_d$ (with Yates' continuity correction). Reject at $\alpha = 0.05$ if $|z_d| > 1.96$. Per-digit $Z$ does not control the family-wise error rate across the nine cells — it is a *diagnostic*: if cell 1 alone is flagged, the data are short of leading 1s; if cells 8 and 9 are flagged, the data show round-number bias.
 
-The rule for choosing among the four:
+Each test answers a different question, so the rule for choosing is to match the question to the test:
 
 | Question | Test |
 |---|---|
@@ -173,7 +175,7 @@ The rule for choosing among the four:
 | Forensic-scale audit, $n \gg 10^5$ | MAD |
 | *Which* digit is off? | per-digit $Z$ |
 
-In practice, run all four. The implementation is `src.conformity.conformity_report`.
+In practice, run all four — they cost almost nothing on top of computing $\hat P$ once, and each catches a kind of deviation the others miss. The implementation is `src.conformity.conformity_report`.
 
 ---
 

--- a/article/benford-law-til.md
+++ b/article/benford-law-til.md
@@ -4,6 +4,12 @@
 
 ---
 
+## Why I'm writing about this
+
+I recently reread *The Drunkard's Walk* and stumbled again on the paragraph where Mlodinow mentions, almost in passing, Benford's Law — the uncomfortable idea that the first digit of "any" natural dataset is not uniformly distributed but follows a logarithmic curve. On first reading I had accepted the fact as a curiosity; this time I wanted to understand why. What began as a margin note turned into this TIL: an honest attempt to reconstruct the law from two independent arguments, watch the data fit the curve, and close the loop with a concrete application — fraud detection. What follows is the clean notebook of that rereading.
+
+---
+
 ## 1. The worn pages of a logarithm table
 
 In 1881 the astronomer Simon Newcomb noticed something odd while flipping through his copy of a book of logarithms. The early pages — those for numbers starting with 1 — were filthy and dog-eared; the later pages, for numbers starting with 9, were crisp and clean. A logarithm table is the most stubbornly mechanical of references. There is no plot, no narrative, no way for some chapters to be more interesting than others. So why were the early pages worn out?
@@ -181,23 +187,25 @@ In practice, run all four — they cost almost nothing on top of computing $\hat
 
 ## 6. Fraud demo: when fabricated numbers betray themselves
 
-Phase 5 closes the loop. Take a clean Benford-conforming dataset, replace a fraction of its entries with fabricated values, and watch the four-test bundle cross from *accept* to *reject*.
+§5 set up the conformity bundle on clean data; §6 puts it to work in an adversarial setting. Take a clean Benford-conforming dataset, replace a fraction of its entries with fabricated values, and watch the four-test bundle cross from *accept* to *reject*. The setup is deliberately stylised — there is no real fraudster on the other side, and we control everything — but it is the cleanest way to see what kind of contamination the bundle catches and what it lets through. The point is not to prove that the bundle works; it is to read off where its threshold sits.
 
 ![Clean vs 30%-contaminated city populations.](../figures/fraud_before_after.png)
 
-The fabricated batch is calibrated to look superficially plausible: drawn over the same magnitude window as the original data, so the fraud signal lives in the *digit distribution* and not in the order of magnitude. Three fabrication strategies are implemented in `src.fraud`:
+The before-and-after figure shows the same GeoNames `cities5000` dataset ($n \approx 68{,}000$) before contamination, on the left, and after replacing 30 % of its entries with fabricated values, on the right. The Benford curve does not move; what moves are the empirical bars, and the bundle reads off the gap.
 
-1. **Uniform-digit.** Each leading digit appears in about $11.1\,\%$ of the entries. The textbook violation.
-2. **Round numbers.** Values cluster at $100, 200, 250, 500, 1{,}000, 2{,}000, 5{,}000, 10{,}000$, mimicking the fraudster who rounds mentally.
-3. **Psychological.** Humans asked to write "random" numbers over-pick the mid digits 3–6 and under-pick 1 and 9.
+The fabricated batch is calibrated to look superficially plausible: drawn over the same magnitude window as the original data, so the fraud signal lives in the *digit distribution* and not in the order of magnitude. This is the realistic threat model — a fraudster who copies the right scale and gets the digits wrong, not one who invents nine-digit revenues for a small business. Three fabrication strategies are implemented in `src.fraud`:
 
-Sweeping the contamination fraction from 0 % to 100 % and running the four-test bundle 30 times at each level gives the **detection-power curve**:
+1. **Uniform-digit.** Each leading digit appears in about $11.1\,\%$ of the entries. The textbook violation — the easiest to catch because it scrambles the curve everywhere at once.
+2. **Round numbers.** Values cluster at $100, 200, 250, 500, 1{,}000, 2{,}000, 5{,}000, 10{,}000$, mimicking the fraudster who rounds mentally. Subtle, because round numbers preserve a leading-digit bias of their own.
+3. **Psychological.** Humans asked to write "random" numbers over-pick the mid digits 3–6 and under-pick 1 and 9 — a reproducible cognitive bias documented in the experimental literature.
+
+Each strategy is a different attack on the curve, so each gives the bundle a different stress test. To turn that into a single picture of detection power, sweep the contamination fraction from 0 % to 100 % and run the four-test bundle 30 times at each level. The result is the **detection-power curve**:
 
 ![Detection power across three fabrication strategies on the GeoNames cities5000 dataset.](../figures/fraud_detection_power.png)
 
 The MAD curve climbs through Nigrini's verdict tiers (acceptable → marginally acceptable → non-conformity) within the first 5–10 % of contamination. The Pearson $\chi^2$ statistic — log-scale — climbs steeply through its $\alpha = 0.05$ critical value of 15.51 at roughly the same point. The empirical rejection rate at $\alpha = 0.05$ saturates near 1 for all three fabrication kinds by 10–15 % contamination.
 
-The reading: at this sample size, a Benford-style audit reliably detects fraud whenever 10 % or more of the entries are fabricated by any of the three strategies. Below 5 %, detection power varies — round-number fabrication is the hardest to catch because it preserves the leading-digit bias of Benford while displacing it onto digits $1$, $2$ and $5$.
+The reading: at this sample size, a Benford-style audit reliably detects fraud whenever 10 % or more of the entries are fabricated by any of the three strategies. Below 5 %, detection power varies — round-number fabrication is the hardest to catch because it preserves the leading-digit bias of Benford while displacing it onto digits $1$, $2$ and $5$. The bundle is not a magic detector; it is a coarse filter that flags gross contamination cheaply and leaves the auditor to decide where to look closer.
 
 This experiment is not just a toy. Documented historical cases include:
 
@@ -211,19 +219,21 @@ The script `scripts/exp_fraud_demo.py` reproduces the *mechanism* by which these
 
 ## 7. When Benford fails, and why that is also useful
 
-Benford's Law is not a universal law of numbers. It applies to datasets whose values span several orders of magnitude *multiplicatively* and are generated by a process that mixes scales. It fails — sharply — for at least three classes of data:
+§6 showed the bundle catching deliberate contamination. The flip side is worth being explicit about: Benford is not a universal law of numbers, and there are honest datasets where it has no business holding. Knowing the boundary is part of using the tool — applying a Benford test to data outside its operating range produces false positives, not insight. The law applies to datasets whose values span several orders of magnitude *multiplicatively* and are generated by a process that mixes scales. It fails — sharply — for at least three classes of data:
 
-1. **Bounded data on an additive scale.** Adult heights, body temperatures, IQ scores, exam grades. The values sit within one order of magnitude, so the log-mantissa $Y$ is sharply concentrated and the first-digit distribution collapses to whatever digit dominates the support. §2's heights example is the textbook case.
+1. **Bounded data on an additive scale.** Adult heights, body temperatures, IQ scores, exam grades. The values sit within one order of magnitude, so the log-mantissa $Y$ is sharply concentrated and the first-digit distribution collapses to whatever digit dominates the support. §2's heights example is the textbook case — a single tall bar at $d = 1$ and zeros elsewhere.
 
-2. **Assigned identifiers.** Phone numbers, ZIP codes, social security numbers, ID document numbers. These are sampled from a fixed combinatorial design, not generated by a multiplicative process; the leading digit is a structural artefact of the issuing authority.
+2. **Assigned identifiers.** Phone numbers, ZIP codes, social security numbers, ID document numbers. These are sampled from a fixed combinatorial design, not generated by a multiplicative process; the leading digit is a structural artefact of the issuing authority, not of any underlying random process. There is nothing for a Benford test to find here, and a "violation" only tells you that the data have a deliberate structure.
 
-3. **Truncated data.** Any dataset with a hard floor or ceiling distorts the leading-digit distribution near the cutoff. The GeoNames `cities5000` data show a small spike at $d = 5$ for exactly this reason — every city *just* over the 5,000-population threshold has a leading 5.
+3. **Truncated data.** Any dataset with a hard floor or ceiling distorts the leading-digit distribution near the cutoff. The GeoNames `cities5000` data show a small spike at $d = 5$ for exactly this reason — every city *just* over the 5,000-population threshold has a leading 5. The test still works, but the analyst has to know the truncation is there before reading the spike as fraud.
 
-The failures are operationally useful. A dataset that *should* conform to Benford and does not is a flag: either the data-generating process is not what you thought, or the data have been tampered with. Forensic accounting uses this asymmetrically — a Benford-conforming dataset is uninformative; a Benford-failing dataset is the question worth asking.
+The failures are operationally useful, and the asymmetry is the point. A dataset that *should* conform to Benford and does not is a flag: either the data-generating process is not what you thought, or the data have been tampered with. Forensic accounting uses this asymmetrically — a Benford-conforming dataset is uninformative on its own; a Benford-failing dataset is the question worth asking. The law is most powerful not when it confirms but when it refuses to.
 
 ---
 
 ## 8. Takeaways
+
+Five points to leave on the table:
 
 1. **The Benford PMF $P(d) = \log_{10}(1 + 1/d)$ is structural, not coincidental.** Two unrelated derivations — log-uniform mantissa and scale invariance — converge on the same curve. The convergence is the evidence.
 

--- a/article/benford-law-til.md
+++ b/article/benford-law-til.md
@@ -98,7 +98,7 @@ So the first derivation answers the question "*given* a log-uniform mantissa, wh
 
 ## 4. Second derivation: scale invariance forces $1/x$
 
-Currency is the cleanest motivation. Take a dataset of revenues in BRL. Convert to USD by multiplying every entry by some exchange rate $c$. The leading-digit distribution should not change just because we relabelled the unit. Formally:
+Currency is the cleanest motivation. Take a dataset of revenues in BRL. Convert to USD by multiplying every entry by some exchange rate $c$. The leading-digit distribution should not change just because we relabelled the unit — the dollar and the real are arbitrary tags, and the underlying economic activity does not know which one we picked. That informal expectation is a *symmetry* claim about the data, not a statistical one. Formally:
 
 **Scale invariance.** For every $c > 0$ and every digit $d$ from $1$ to $9$,
 
@@ -106,19 +106,19 @@ $$
 \Pr[D(cX) = d] = \Pr[D(X) = d].
 $$
 
-This is a strong constraint. It rules out, for example, the uniform distribution on digits — uniform under one currency will not be uniform after multiplying every value by $\pi$.
+This is a strong constraint. It rules out, for example, the uniform distribution on digits — uniform under one currency will not be uniform after multiplying every value by $\pi$. Even before any derivation, the requirement already narrows the candidate distributions sharply.
 
-Take logs again. With $Y = \log_{10}(X) \bmod 1$ and $\alpha = \log_{10}(c) \bmod 1$, the multiplication $X \mapsto cX$ acts on $Y$ as a translation:
+The natural move is again to pass to logs, because logs turn multiplication into addition. With $Y = \log_{10}(X) \bmod 1$ and $\alpha = \log_{10}(c) \bmod 1$, the operation $X \mapsto cX$ becomes $\log_{10}(X) \mapsto \log_{10}(X) + \log_{10}(c)$, which on the log-mantissa is a translation:
 
 $$
 Y \mapsto (Y + \alpha) \bmod 1.
 $$
 
-The set of attainable $\alpha$ as $c$ ranges over $(0, \infty)$ is the entire interval $[0, 1)$. So scale invariance is *equivalent* to translation invariance of $Y$ on the circle $\mathbb{R}/\mathbb{Z}$. And there is exactly one translation-invariant probability distribution on the circle: the uniform distribution.
+As $c$ ranges over $(0, \infty)$, $\log_{10}(c)$ ranges over all of $\mathbb{R}$, so $\alpha = \log_{10}(c) \bmod 1$ takes every value in $[0, 1)$. Scale invariance of $X$ is therefore *equivalent* to translation invariance of $Y$ on the circle $\mathbb{R}/\mathbb{Z}$. And there is exactly one translation-invariant probability distribution on the circle: the uniform distribution. The intuition is symmetry — any other distribution would have a "preferred point" that translation would move, contradicting invariance. (Formally, this is the uniqueness of Haar measure on a compact group.)
 
 Scale invariance therefore forces $Y \sim \mathrm{Uniform}(0, 1)$, which by §3 forces the Benford PMF. The argument is clean enough to deserve a name; it is **Pinkham's theorem**.
 
-There is a complementary route through the *density* rather than the log-mantissa. On a finite window $[a, b] \subset (0, \infty)$ the only probability density invariant under multiplication is
+A complementary route works directly with the *density* on $X$ rather than passing through the log-mantissa, and is worth seeing because it makes the $1/x$ shape explicit. Under $X \mapsto cX$ a probability density transforms as $f(x) \mapsto \frac{1}{c} f(x/c)$. Demanding that this equal $f(x)$ for every $c > 0$ forces $f(x) \propto 1/x$. So on a finite window $[a, b] \subset (0, \infty)$ the only probability density invariant under multiplication is
 
 $$
 f(x) = \frac{1}{x \log(b/a)}.
@@ -130,7 +130,7 @@ $$
 P(D = d) = \int_{d \cdot 10^k}^{(d+1) \cdot 10^k} \frac{1}{x \ln 10}\, dx = \log_{10}\left(1 + \frac{1}{d}\right).
 $$
 
-The factor $10^k$ cancels. That cancellation *is* the scale invariance, made arithmetic.
+The factor $10^k$ cancels. That cancellation *is* the scale invariance, made arithmetic: the leading-digit probability does not depend on which decade we restrict to.
 
 ![Multiplying world city populations by various constants. The first-digit distribution does not move.](../figures/scale_invariance.png)
 


### PR DESCRIPTION
## Summary

Delivers the full v0.7 draft of the Benford's Law TIL in two parallel
files: `article/benford-law-til.md` (canonical English) and
`article/benford-law-til-pt-BR.md` (PT-BR review copy). The two files
are now line-for-line equivalent, diverging only by language.

The article walks the reader from Newcomb's worn logarithm pages through
two independent rigorous derivations (log-uniform mantissa and Pinkham's
scale invariance) into a four-test conformity bundle and an end-to-end
fraud-detection demo, closing with the boundary conditions where the law
fails and a five-point summary.

## Type of Change

- [ ] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [x] Documentation (`docs`)

## Deliverables

- `article/benford-law-til.md` — full English draft (260 lines, ~3,200 words)
- `article/benford-law-til-pt-BR.md` — PT-BR review copy (260 lines, equivalent)
- `notebooks/02_log_uniform_derivation.ipynb` — refactored to non-integer
  `k` so the convergence of the log-mantissa to uniform is visually
  demonstrable in the §3 figure
- `figures/log_uniform_intuition.png` — regenerated from the updated
  notebook
- All other figures (`empirical_match.png`, `scale_invariance.png`,
  `conformity_test_demo.png`, `fraud_before_after.png`,
  `fraud_detection_power.png`) referenced in place
